### PR TITLE
feat: export historical whale activity to CSV / JSON

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,9 @@ import time
 import logging
 import requests
 import yaml
+import csv
+import json
+import argparse
 from datetime import datetime, timezone
 from dotenv import load_dotenv
 from colorama import init, Fore, Style
@@ -228,6 +231,36 @@ def send_telegram_alert(bot_token: str, chat_id: str, message: str) -> bool:
         return False
 
 
+def export_trade(file_path: str, trade_data: dict) -> None:
+    """Export trade data to a CSV or JSON file."""
+    if not file_path:
+        return
+
+    ext = os.path.splitext(file_path)[1].lower()
+    
+    if ext == ".csv":
+        file_exists = os.path.isfile(file_path)
+        with open(file_path, "a", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=trade_data.keys())
+            if not file_exists:
+                writer.writeheader()
+            writer.writerow(trade_data)
+    elif ext == ".json":
+        all_data = []
+        if os.path.isfile(file_path):
+            try:
+                with open(file_path, "r") as f:
+                    all_data = json.load(f)
+            except (json.JSONDecodeError, ValueError):
+                all_data = []
+        
+        all_data.append(trade_data)
+        with open(file_path, "w") as f:
+            json.dump(all_data, f, indent=2)
+    else:
+        logger.warning(f"Unsupported export format: {ext}. Use .csv or .json.")
+
+
 # ─────────────────────────────────────────────
 # Market info cache (avoid hammering the API)
 # ─────────────────────────────────────────────
@@ -253,7 +286,7 @@ def get_market_title(condition_id: str) -> str:
 # ─────────────────────────────────────────────
 # Main loop
 # ─────────────────────────────────────────────
-def run(config: dict) -> None:
+def run(config: dict, export_path: str = None) -> None:
     """Main monitoring loop."""
     min_size = float(config["min_trade_size"])
     interval = int(config["check_interval"])
@@ -273,6 +306,8 @@ def run(config: dict) -> None:
     print(f"  Min trade size : {Fore.YELLOW}${min_size:,.0f}{Style.RESET_ALL}")
     print(f"  Check interval : {Fore.YELLOW}{interval}s{Style.RESET_ALL}")
     print(f"  Telegram alerts: {Fore.GREEN+'ON' if telegram_enabled else Fore.RED+'OFF'}{Style.RESET_ALL}")
+    if export_path:
+        print(f"  Export path    : {Fore.YELLOW}{export_path}{Style.RESET_ALL}")
     print(f"{Fore.CYAN}{'═' * 50}{Style.RESET_ALL}\n")
 
     if not telegram_enabled:
@@ -343,6 +378,19 @@ def run(config: dict) -> None:
                 ok = send_telegram_alert(bot_token, chat_id, tg_msg)
                 if ok:
                     logger.debug("✅ Telegram alert sent.")
+            
+            # Export if path is provided
+            if export_path:
+                trade_record = {
+                    "timestamp": ts,
+                    "market": market_title,
+                    "side": side,
+                    "amount_usd": round(amount_usd, 2),
+                    "price": price,
+                    "market_url": f"https://polymarket.com/event/{condition_id}" if condition_id else ""
+                }
+                export_trade(export_path, trade_record)
+                logger.debug(f"💾 Trade exported to {export_path}")
 
         # Update seen set (keep it bounded)
         seen_ids = new_seen
@@ -358,14 +406,15 @@ def run(config: dict) -> None:
 # Entry point
 # ─────────────────────────────────────────────
 if __name__ == "__main__":
-    cfg_path = "config.yaml"
-    if len(sys.argv) > 1:
-        cfg_path = sys.argv[1]
+    parser = argparse.ArgumentParser(description="Polymarket Whale Tracker")
+    parser.add_argument("--config", default="config.yaml", help="Path to YAML config file")
+    parser.add_argument("--export", help="Export path (CSV or JSON)")
+    args = parser.parse_args()
 
-    config = load_config(cfg_path)
+    config = load_config(args.config)
 
     try:
-        run(config)
+        run(config, export_path=args.export)
     except KeyboardInterrupt:
         print(f"\n{Fore.YELLOW}👋 Whale Tracker stopped.{Style.RESET_ALL}\n")
         sys.exit(0)


### PR DESCRIPTION
Fixes #5

### Changes
- Added `--export` CLI argument to dump whale trades to a file.
- Supports both `.csv` and `.json` formats.
- Added `export_trade` helper function to handle incremental appending to CSV/JSON files.
- Replaced manual `sys.argv` handling with `argparse` for better CLI usability.